### PR TITLE
io.connect() seems to work locally. This should make deployment easier.

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,6 +1,6 @@
 var bingo = angular.module('bingo', ['ngRoute', 'btford.socket-io', 'ngMaterial'])
   .factory('bingosockets', function(socketFactory) {
-    var myIoSocket = io.connect('https://bingojs.herokuapp.com');
+    var myIoSocket = io.connect();
     var scks = socketFactory({
       ioSocket: myIoSocket
     });


### PR DESCRIPTION
Making call to `io.connect()` nonspecific for working locally and on heroku.
