### PR TITLE
Stylize supportpages [addCardSet]

### DIFF
--- a/public/css/addCardSet.css
+++ b/public/css/addCardSet.css
@@ -1,5 +1,6 @@
 .addCardSet {
   background-color: #0058AE;
+  /*background: rgb(225, 225, 225);*/
   width: 100%;
   /*text-align: center;*/
   position: absolute;

--- a/public/css/addCardSet.css
+++ b/public/css/addCardSet.css
@@ -22,9 +22,9 @@
 */
 }
 
-.addCardSet .container {
+.addCardSet .nocontainer {
   border-radius: 3px;
-  background-color: white;
+  /*background-color: white;*/
   margin-left:15%;
   margin-right: 15%;
   width: 70%;
@@ -36,3 +36,33 @@
   box-shadow:         .1rem .1rem .5rem #333;
 }
 
+/*.addCardSet .cardsetformholder {
+  overflow-y: auto;
+  height: 100%;
+}*/
+
+.addCardSet md-card {
+  max-height: 80vh;
+  background-color: white;
+}
+
+.addCardSet md-card-content{
+  max-height: 70vh;
+  width: 100%;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+
+.addCardSet .container {
+  margin-top: 70px;
+}
+
+.addCardSet .md-actions {
+  width: 100%;
+  height: 40px;
+  padding-right: 40px;
+}
+
+.addCardSet .addcs {
+  margin-top: 15px;
+}

--- a/public/css/addCardSet.css
+++ b/public/css/addCardSet.css
@@ -1,14 +1,38 @@
+.addCardSet {
+  background-color: #0058AE;
+  width: 100%;
+  /*text-align: center;*/
+  position: absolute;
+  top:0;
+  height: 100vh;
+}
+
 .addCardSet input {
 	border-radius: 3px;
 	padding:.5rem;
 }
 
 .addCardSet h2 {
-	text-align: center;
-	padding: 2rem;
-	font-size: 3.5rem;
+  font-size: 3.5rem;
+  color: #333;
 }
 
 .addCardSet .cardSetName {
-	text-align: center;
+/*  text-align: center;
+*/
 }
+
+.addCardSet .container {
+  border-radius: 3px;
+  background-color: white;
+  margin-left:15%;
+  margin-right: 15%;
+  width: 70%;
+  position: absolute;
+  top:9rem;
+  height: 75vh;
+    -webkit-box-shadow:  .1rem .1rem .5rem #333;  /* Safari 3-4, iOS 4.0.2 - 4.2, Android 2.3+ */
+  -moz-box-shadow:    .1rem .1rem .5rem #333;  /* Firefox 3.5 - 3.6 */
+  box-shadow:         .1rem .1rem .5rem #333;
+}
+

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -1,3 +1,7 @@
+body {
+  background: rgb(225, 225, 225);
+}
+
 .home .banner {
   text-align: center;
   background-color: #0F63C8;
@@ -46,5 +50,5 @@
 }
 
 .home section {
-	background: white;
+  background: white;
 }

--- a/public/css/newGame.css
+++ b/public/css/newGame.css
@@ -1,35 +1,38 @@
 .newGame {
-	background-color: #0058AE;
-	width: 100%;
-	text-align: center;
-	position: absolute;
-	top:0;
-	height: 100vh;
+  background-color: #0058AE;
+  width: 100%;
+  text-align: center;
+  position: absolute;
+  top: 0;
+  height: 100vh;
 }
 
 .newGame .container {
-	border-radius: 3px;
-	background-color: white;
-	margin-left:15%;
-	margin-right: 15%;
-	width: 70%;
-	position: absolute;
-	top:9rem;
-	height: 75vh;
-	  -webkit-box-shadow:  .1rem .1rem .5rem #333;  /* Safari 3-4, iOS 4.0.2 - 4.2, Android 2.3+ */
-  -moz-box-shadow:    .1rem .1rem .5rem #333;  /* Firefox 3.5 - 3.6 */
-  box-shadow:         .1rem .1rem .5rem #333;
+  border-radius: 3px;
+  background-color: white;
+  margin-left: 15%;
+  margin-right: 15%;
+  width: 70%;
+  position: absolute;
+  top: 9rem;
+  height: 75vh;
+  -webkit-box-shadow: .1rem .1rem .5rem #333;
+  /* Safari 3-4, iOS 4.0.2 - 4.2, Android 2.3+ */
+
+  -moz-box-shadow: .1rem .1rem .5rem #333;
+  /* Firefox 3.5 - 3.6 */
+
+  box-shadow: .1rem .1rem .5rem #333;
 }
 
 .newGame h2 {
-	font-size: 3.5rem;
-	color: #333;
+  font-size: 3.5rem;
+  color: #333;
 }
 
 .newGame .options {
-	padding:.5rem 5rem;
-	height: 30vh;
-	overflow: scroll;
-	text-align: left;
+  padding: .5rem 5rem;
+  height: 30vh;
+  overflow: scroll;
+  text-align: left;
 }
-

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -13,7 +13,6 @@ html,
 body {
   font-family: 'Lato', sans-serif;
   opacity: .99;
-  background: rgb(225, 225, 225);
 }
 
 .col-xs-5th,

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,4 +1,4 @@
-var bingo = angular.module('bingo', ['ngRoute', 'btford.socket-io', 'ngMaterial', 'ngMessages'])
+var bingo = angular.module('bingo', ['ngRoute', 'ngTouch', 'btford.socket-io', 'ngMaterial', 'ngMessages'])
   .factory('bingosockets', function(socketFactory) {
     var myIoSocket = io.connect('http://localhost:3000');
     var scks = socketFactory({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -60,21 +60,25 @@ bingo.config(function($routeProvider) {
 bingo.controller('addCardSetController', function($scope, $http, bingosockets) {
   $scope.formData = {};
   $scope.formData.name = "";
+  $scope.choices = [];
+  console.log($scope.choices.length);
 
-  $scope.choices = [{
-    id: 'choice1'
-  }, {
-    id: 'choice2'
-  }, {
-    id: 'choice3'
-  }];
-
-  $scope.addNewChoice = function() {
+  $scope.addNewChoice = function(event) {
+    if (event) {
+      event.preventDefault();
+    }
     var newItemNo = $scope.choices.length + 1;
     $scope.choices.push({
       'id': 'choice' + newItemNo
     });
   };
+
+  generatenewchoices = function(blanks) {
+    for (var i = 0; i <= blanks; i++) {
+      $scope.addNewChoice();
+    }
+  };
+  generatenewchoices(25);
 
   $scope.showAddChoice = function(choice) {
     return choice.id === $scope.choices[$scope.choices.length - 1].id;
@@ -82,18 +86,21 @@ bingo.controller('addCardSetController', function($scope, $http, bingosockets) {
 
   $scope.addCardSet = function() {
     cards = [];
+    var dupenames = [];
     // quadratic performance, ok for small cardset, optimize if necessary
     for (var i in $scope.choices) {
       if (cards.indexOf($scope.choices[i].name) === -1) {
         if ($scope.choices[i].name != null) {
           cards.push($scope.choices[i].name);
         }
+      } else {
+        dupenames.push($scope.choices[i].name);
       }
     }
     if ($scope.formData.name == "") {
       confirm("card set has no name, please add one.")
     } else if (cards.length < 25) {
-      confirm("not enough unique cards (25), please add more.")
+      confirm("There are not at least 25 unique squares.")
     } else {
       postdata = {
         "name": $scope.formData.name,

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,4 +1,4 @@
-var bingo = angular.module('bingo', ['ngRoute', 'btford.socket-io', 'ngMaterial'])
+var bingo = angular.module('bingo', ['ngRoute', 'btford.socket-io', 'ngMaterial', 'ngMessages'])
   .factory('bingosockets', function(socketFactory) {
     var myIoSocket = io.connect('http://localhost:3000');
     var scks = socketFactory({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -15,18 +15,18 @@ var bingo = angular.module('bingo', ['ngRoute', 'ngTouch', 'btford.socket-io', '
     return scks;
   })
   .factory('focus', function($timeout) {
-     return function(id) {
-       // timeout makes sure that it is invoked after any other event has been triggered.
-       // e.g. click events that need to run before the focus or
-       // inputs elements that are in a disabled state but are enabled when those events
-       // are triggered.
-       $timeout(function() {
-         var element = document.getElementById(id);
-         if(element)
-           element.focus();
-       });
-     };
-   })
+    return function(id) {
+      // timeout makes sure that it is invoked after any other event has been triggered.
+      // e.g. click events that need to run before the focus or
+      // inputs elements that are in a disabled state but are enabled when those events
+      // are triggered.
+      $timeout(function() {
+        var element = document.getElementById(id);
+        if (element)
+          element.focus();
+      });
+    };
+  })
   .config(function($mdThemingProvider) {
     $mdThemingProvider.theme('default')
       .primaryPalette('purple', {
@@ -47,18 +47,18 @@ bingo.directive('bsquare', function() {
 });
 
 bingo.directive('eventFocus', function(focus) {
-    return function(scope, elem, attr) {
-      elem.on(attr.eventFocus, function() {
-        focus(attr.eventFocusId);
-      });
+  return function(scope, elem, attr) {
+    elem.on(attr.eventFocus, function() {
+      focus(attr.eventFocusId);
+    });
 
-      // Removes bound events in the element itself
-      // when the scope is destroyed
-      scope.$on('$destroy', function() {
-        elem.off(attr.eventFocus);
-      });
-    };
-  });
+    // Removes bound events in the element itself
+    // when the scope is destroyed
+    scope.$on('$destroy', function() {
+      elem.off(attr.eventFocus);
+    });
+  };
+});
 
 bingo.config(function($routeProvider) {
   $routeProvider

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -57,9 +57,9 @@ bingo.config(function($routeProvider) {
     });
 });
 
-bingo.controller('addCardSetController', function($scope, $http, bingosockets) {
+bingo.controller('addCardSetController', function($scope, $http, $location, $mdDialog, bingosockets) {
   $scope.formData = {};
-  $scope.formData.name = "";
+  $scope.formData.CardSetName = "";
   $scope.choices = [];
   console.log($scope.choices.length);
 
@@ -97,19 +97,28 @@ bingo.controller('addCardSetController', function($scope, $http, bingosockets) {
         dupenames.push($scope.choices[i].name);
       }
     }
-    if ($scope.formData.name == "") {
+    if ($scope.formData.CardSetName == "") {
       confirm("card set has no name, please add one.")
     } else if (cards.length < 25) {
       confirm("There are not at least 25 unique squares.")
     } else {
       postdata = {
-        "name": $scope.formData.name,
+        "name": $scope.formData.CardSetName,
         "cards": cards
       };
       $http.post('/api/new/cardset', postdata)
         .success(function(data) {
           // clear form? redirect?
-          confirm("Congratulations! You have successfully added your card set!")
+          $mdDialog.show(
+                  $mdDialog.alert()
+                  .title('New Card Set')
+                  .content('You\'ve successfully added a new card set!')
+                  .ariaLabel('New card set confirmation')
+                  .ok('Home Page')
+                )
+                .finally(function() {
+                  $location.path('/');
+                });
         })
         .error(function(data) {
           console.log("Error: " + data);

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -1,12 +1,41 @@
-<div class = "addCardSet">
-<h2>Add a New Card Set</h2>
-<form>
-  <input type = "text" name = "name" placeholder = "Bingo card set name" ng-model = formData.name >
+<div class="addCardSet">
+  <div class="container">
+    <h2>Add a New Card Set</h2>
+    <form name="projectForm">
+      <md-input-container>
+        <label>Description</label>
+        <input md-maxlength="30" required name="description" ng-model="project.description">
+        <div ng-messages="projectForm.description.$error">
+          <div ng-message="required">This is required.</div>
+          <div ng-message="md-maxlength">The name has to be less than 30 characters long.</div>
+        </div>
+      </md-input-container>
+      <md-input-container>
+        <label>Client Name</label>
+        <input required name="clientName" ng-model="project.clientName">
+        <div ng-messages="projectForm.clientName.$error">
+          <div ng-message="required">This is required.</div>
+        </div>
+      </md-input-container>
+      <md-input-container>
+        <label>Hourly Rate (USD)</label>
+        <input required type="number" step="any" name="rate" ng-model="project.rate" min="800" max="4999">
+        <div ng-messages="projectForm.rate.$error">
+          <div ng-message="required">You've got to charge something! You can't just <b>give away</b> a Missile Defense System.</div>
+          <div ng-message="min">You should charge at least $800 an hour. This job is a big deal... if you mess up, everyone dies!</div>
+          <div ng-message="max">$5,000 an hour? That's a little ridiculous. I doubt event Bill Clinton could afford that.</div>
+        </div>
+      </md-input-container>
+    </form>
+  </div>
+</div>
+<!-- <form>
+  <input type="text" name="name" placeholder="Bingo card set name" ng-model="formData.name">
   <br>
   <div class="form-group" data-ng-repeat="choice in choices">
     <label for="choice" ng-show="showChoiceLabel(choice)">Choices</label>
     <input type="text" ng-model="choice.name" name="" placeholder="Bingo card square entry">
     <button ng-show="showAddChoice(choice)" ng-click="addNewChoice()">Add another card</button>
   </div>
-  <button type = "submit" ng-click = "addCardSet()">Add!</button>
-</form>
+  <button type="submit" ng-click="addCardSet()">Add!</button>
+</form> -->

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -12,16 +12,18 @@
               <div ng-message="md-maxlength">We suggest limiting the name to fewer than 30 characters.</div>
             </div>
           </md-input-container>
-          <md-input-container ng-repeat="newcard in choices" layout='column'>
-            <label flex-order="1">Square {{$index + 1}}</label>
-            <input flex-order="2" id="sqin_{{$index + 1}}" md-maxlength="15" required name="squarename{{$index}}" ng-model="choices[$index].name">
-            <div flex-order="3" ng-messages="newCardSetForm.squarename{{$index}}.$error">
-              <div ng-message="md-maxlength">We recommend this using fewer than 15 characters.</div>
-            </div>
-            <md-button flex-order="4" ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice(true)" aria-label="Add new square">
+          <div ng-repeat="newcard in choices">
+            <md-input-container layout='column'>
+              <label flex-order="1">Square {{$index + 1}}</label>
+              <input flex-order="2" id="sqin_{{$index + 1}}" md-maxlength="15" required name="squarename{{$index}}" ng-model="choices[$index].name">
+              <div flex-order="3" ng-messages="newCardSetForm.squarename{{$index}}.$error">
+                <div ng-message="md-maxlength">We recommend this using fewer than 15 characters.</div>
+              </div>
+            </md-input-container>
+            <md-button ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice(true)" aria-label="Add new square">
               <md-icon md-font-icon="fa fa-plus" style="color: white;"></md-icon>
             </md-button>
-          </md-input-container>
+          </div>
         </form>
       </md-card-content>
       <div class="md-actions" flex-order="3" layout="row" layout-align="end center">

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -3,7 +3,7 @@
     <md-card layout='column' layout-margin layout-align="space-between center">
       <h2 flex-order="1">Add a New Card Set</h2>
       <md-card-content flex-order="2">
-        <form name="newCardSetForm">
+        <form novalidate name="newCardSetForm">
           <md-input-container>
             <label>"Name"</label>
             <input md-maxlength="30" required name="CardSetName" ng-model="formData.CardSetName">
@@ -24,7 +24,7 @@
         </form>
       </md-card-content>
       <div class="md-actions" flex-order="3" layout="row" layout-align="end center">
-        <md-button class="md-raised md-accent">Add Card Set</md-button>
+        <md-button class="md-raised md-accent" type="submit" ng-click="addCardSet()">Add Card Set</md-button>
       </div>
     </md-card>
   </div>

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -9,14 +9,14 @@
             <input md-maxlength="30" required name="CardSetName" ng-model="formData.CardSetName">
             <div ng-messages="newCardSetForm.CardSetName.$error">
               <div ng-message="required">This is required.</div>
-              <div ng-message="md-maxlength">The name has to be less than 30 characters long.</div>
+              <div ng-message="md-maxlength">We suggest limiting the name to fewer than 30 characters.</div>
             </div>
           </md-input-container>
           <md-input-container ng-repeat="newcard in choices" layout='column'>
             <label flex-order="1">Square {{$index + 1}}</label>
-            <input flex-order="2" id="sqin_{{$index + 1}}" md-maxlength="15" required name="squarename" ng-model="choices[$index].name">
-            <div flex-order="3" ng-messages="newCardSetForm.squarename.$error">
-              <div ng-message="md-maxlength">This must be less than 15 characters long.</div>
+            <input flex-order="2" id="sqin_{{$index + 1}}" md-maxlength="15" required name="squarename{{$index}}" ng-model="choices[$index].name">
+            <div flex-order="3" ng-messages="newCardSetForm.squarename{{$index}}.$error">
+              <div ng-message="md-maxlength">We recommend this using fewer than 15 characters.</div>
             </div>
             <md-button flex-order="4" ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice(true)" aria-label="Add new square">
               <md-icon md-font-icon="fa-plus" style="color: white;"></md-icon>

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -1,32 +1,32 @@
 <div class="addCardSet">
   <div class="container">
-    <h2>Add a New Card Set</h2>
-    <form name="projectForm">
-      <md-input-container>
-        <label>Description</label>
-        <input md-maxlength="30" required name="description" ng-model="project.description">
-        <div ng-messages="projectForm.description.$error">
-          <div ng-message="required">This is required.</div>
-          <div ng-message="md-maxlength">The name has to be less than 30 characters long.</div>
-        </div>
-      </md-input-container>
-      <md-input-container>
-        <label>Client Name</label>
-        <input required name="clientName" ng-model="project.clientName">
-        <div ng-messages="projectForm.clientName.$error">
-          <div ng-message="required">This is required.</div>
-        </div>
-      </md-input-container>
-      <md-input-container>
-        <label>Hourly Rate (USD)</label>
-        <input required type="number" step="any" name="rate" ng-model="project.rate" min="800" max="4999">
-        <div ng-messages="projectForm.rate.$error">
-          <div ng-message="required">You've got to charge something! You can't just <b>give away</b> a Missile Defense System.</div>
-          <div ng-message="min">You should charge at least $800 an hour. This job is a big deal... if you mess up, everyone dies!</div>
-          <div ng-message="max">$5,000 an hour? That's a little ridiculous. I doubt event Bill Clinton could afford that.</div>
-        </div>
-      </md-input-container>
-    </form>
+    <md-card layout='column' layout-margin layout-align="space-between center">
+      <h2 flex-order="1">Add a New Card Set</h2>
+      <md-card-content flex-order="2">
+        <form name="newCardSetForm">
+          <md-input-container>
+            <label>"Name"</label>
+            <input md-maxlength="30" required name="CardSetName" ng-model="formData.CardSetName">
+            <div ng-messages="newCardSetForm.CardSetName.$error">
+              <div ng-message="required">This is required.</div>
+              <div ng-message="md-maxlength">The name has to be less than 30 characters long.</div>
+            </div>
+          </md-input-container>
+          <md-input-container ng-repeat="newcard in choices" layout='column'>
+            <label flex-order="1">Square {{$index +1}}</label>
+            <input flex-order="2" required name="squarename" ng-model="choices[$index].name">
+            <div flex-order="3"ng-messages="newCardSetForm.squarename.$error">
+            </div>
+            <md-button flex-order="4" ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice()" aria-label="Add new square">
+              <md-icon md-font-icon="fa-plus" style="color: white;"></md-icon>
+            </md-button>
+          </md-input-container>
+        </form>
+      </md-card-content>
+      <div class="md-actions" flex-order="3" layout="row" layout-align="end center">
+        <md-button class="md-raised md-accent">Add Card Set</md-button>
+      </div>
+    </md-card>
   </div>
 </div>
 <!-- <form>

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -19,7 +19,7 @@
               <div ng-message="md-maxlength">We recommend this using fewer than 15 characters.</div>
             </div>
             <md-button flex-order="4" ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice(true)" aria-label="Add new square">
-              <md-icon md-font-icon="fa-plus" style="color: white;"></md-icon>
+              <md-icon md-font-icon="fa fa-plus" style="color: white;"></md-icon>
             </md-button>
           </md-input-container>
         </form>

--- a/public/pages/addCardSet.html
+++ b/public/pages/addCardSet.html
@@ -13,11 +13,12 @@
             </div>
           </md-input-container>
           <md-input-container ng-repeat="newcard in choices" layout='column'>
-            <label flex-order="1">Square {{$index +1}}</label>
-            <input flex-order="2" required name="squarename" ng-model="choices[$index].name">
-            <div flex-order="3"ng-messages="newCardSetForm.squarename.$error">
+            <label flex-order="1">Square {{$index + 1}}</label>
+            <input flex-order="2" id="sqin_{{$index + 1}}" md-maxlength="15" required name="squarename" ng-model="choices[$index].name">
+            <div flex-order="3" ng-messages="newCardSetForm.squarename.$error">
+              <div ng-message="md-maxlength">This must be less than 15 characters long.</div>
             </div>
-            <md-button flex-order="4" ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice()" aria-label="Add new square">
+            <md-button flex-order="4" ng-if="$last" class="md-fab md-primary addcs" ng-click="addNewChoice(true)" aria-label="Add new square">
               <md-icon md-font-icon="fa-plus" style="color: white;"></md-icon>
             </md-button>
           </md-input-container>

--- a/public/pages/home.html
+++ b/public/pages/home.html
@@ -11,7 +11,7 @@
                 <md-tooltip md-direction="left" md-delay=1000>
                   Create New Game
                 </md-tooltip>
-                <md-icon md-font-icon="fa-plus" style="color: white;"></md-icon>
+                <md-icon md-font-icon="fa fa-plus" style="color: white;"></md-icon>
               </md-button>
             </div>
           </md-toolbar>
@@ -40,7 +40,7 @@
                 <md-tooltip md-direction="left" md-delay=1000>
                   Create New Card Set
                 </md-tooltip>
-                <md-icon md-font-icon="fa-plus" style="color: white;"></md-icon>
+                <md-icon md-font-icon="fa fa-plus" style="color: white;"></md-icon>
               </md-button>
             </div>
           </md-toolbar>
@@ -54,7 +54,7 @@
                   </div>
                   <div flex=10>
                     <md-button class="md-icon-button" ng-click="editCardSet(cardset._id)" aria-label="Edit card set">
-                      <md-icon md-font-icon="fa-pencil-square-o" class=""></md-icon>
+                      <md-icon md-font-icon="fa fa-pencil-square-o" class=""></md-icon>
                       <md-tooltip md-direction="left" md-delay=1000>
                         Edit this card set
                       </md-tooltip>
@@ -62,7 +62,7 @@
                   </div>
                   <div flex=10>
                     <md-button class="md-icon-button" ng-click="deleteCardSet(cardset._id)" aria-label="Delete card set">
-                      <md-icon md-font-icon="fa-minus-square" class=""></md-icon>
+                      <md-icon md-font-icon="fa fa-minus-square" class=""></md-icon>
                       <md-tooltip md-direction="left" md-delay=1000>
                         Delete this card set
                       </md-tooltip>

--- a/public/pages/index.html
+++ b/public/pages/index.html
@@ -51,6 +51,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.min.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-route.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-touch.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.8.3/angular-material.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-messages.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
@@ -60,3 +61,4 @@
 </body>
 
 </html>
+

--- a/public/pages/index.html
+++ b/public/pages/index.html
@@ -52,6 +52,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.min.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-route.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.8.3/angular-material.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-messages.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <script type="text/javascript" src="js/socket.js"></script>

--- a/public/pages/newGame.html
+++ b/public/pages/newGame.html
@@ -1,20 +1,24 @@
-<div class = "newGame">
-	<div class = "container">
-		<h2>Create a new game</h2>
-		<form>
-			<p>Name:</p>
-			<input type = "text" name = "name" placeholder = "Room Name" ng-model = formData.room><br>
-			<p>Start date and time: </p>
-			<!--TODO: Make the start date input more user friendly-->
-			<input type="datetime-local" placeholder="yyyy-MM-ddTHH:mm:ss" min="2001-01-01T00:00:00" max="2020-12-31T00:00:00" ng-model = formData.startDate><br>
-			<p>Select Card Set to Use: </p>
-			<div class = "options">
-				<div ng-repeat="cardset in formText">
-					{{cardset.name}} <input type = "radio" name = "cardset.id" value = "{{cardset._id}}" ng-model = formData.card_set_id>  
-				</div>
-			</div>
-			<button type = "submit" ng-click = "addGame()">Create!</button>
-
-		</form>
-	</div>
+<div class="newGame">
+  <div class="container">
+    <md-content layout-padding>
+      <h2>Create a new game</h2>
+      <form>
+        <p>Name:</p>
+        <input type="text" name="name" placeholder="Room Name" ng-model=formData.room>
+        <br>
+        <p>Start date and time: </p>
+        <!--TODO: Make the start date input more user friendly-->
+        <input type="datetime-local" placeholder="yyyy-MM-ddTHH:mm:ss" min="2001-01-01T00:00:00" max="2020-12-31T00:00:00" ng-model=f ormData.startDate>
+        <br>
+        <p>Select Card Set to Use: </p>
+        <div class="options">
+          <div ng-repeat="cardset in formText">
+            {{cardset.name}}
+            <input type="radio" name="cardset.id" value="{{cardset._id}}" ng-model=f ormData.card_set_id>
+          </div>
+        </div>
+        <button type="submit" ng-click="addGame()">Create!</button>
+      </form>
+    </md-content>
+  </div>
 </div>


### PR DESCRIPTION
Add card set page is updated to work nicely.
- Responsive (works from desktop to phone)
- Sets a recommended character limit on square content
  - Does not stop user from submitting long names, but it will display a visual suggestion that the content be shortened
- Uses an mdDialog to confirm creation of card set and redirect to home page.
- Starts with 25 blank spaces (back-end configurable).
- No hard-coded initialization of `choices` variable.
